### PR TITLE
Added support for overriding the docker-compose command

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -70,6 +70,7 @@ type DeployCF struct {
 type DockerCompose struct {
 	Type          string
 	Name          string
+	Command       string
 	ManualTrigger bool `json:"manual_trigger" yaml:"manual_trigger"`
 	Vars          Vars
 	Service       string

--- a/pipeline/task_dockercompose_test.go
+++ b/pipeline/task_dockercompose_test.go
@@ -58,7 +58,66 @@ func TestRenderDockerComposeTask(t *testing.T) {
 					Run: atc.TaskRunConfig{
 						Path: "/bin/sh",
 						Dir:  gitDir + "/base.path",
-						Args: runScriptArgs(dockerComposeScript(service, expectedVars), "", nil, "../.git/ref"),
+						Args: runScriptArgs(dockerComposeScript(service, expectedVars, ""), "", nil, "../.git/ref"),
+					},
+					Inputs: []atc.TaskInputConfig{
+						{Name: gitDir},
+					},
+				}},
+		}}
+
+	assert.Equal(t, expectedJob, p.Render(man).Jobs[0])
+}
+
+func TestRenderDockerComposeTaskWithCommand(t *testing.T) {
+	p := testPipeline()
+
+	man := manifest.Manifest{
+		Repo: manifest.Repo{
+			URI:      "git@git:user/repo",
+			BasePath: "base.path",
+		},
+		Tasks: []manifest.Task{
+			manifest.DockerCompose{
+				Name:    "",
+				Service: "app",
+				Command: "/usr/bin/a-command",
+				Vars: manifest.Vars{
+					"VAR1": "Value1",
+					"VAR2": "Value2",
+				},
+			},
+		},
+	}
+
+	expectedVars := map[string]string{
+		"VAR1":            "Value1",
+		"VAR2":            "Value2",
+		"GCR_PRIVATE_KEY": "((gcr.private_key))",
+	}
+
+	expectedJob := atc.JobConfig{
+		Name:   "docker-compose",
+		Serial: true,
+		Plan: atc.PlanSequence{
+			atc.PlanConfig{Get: gitDir, Trigger: true},
+			atc.PlanConfig{
+				Task:       "run",
+				Privileged: true,
+				TaskConfig: &atc.TaskConfig{
+					Platform: "linux",
+					Params:   expectedVars,
+					ImageResource: &atc.ImageResource{
+						Type: "docker-image",
+						Source: atc.Source{
+							"repository": strings.Split(config.DockerComposeImage, ":")[0],
+							"tag":        strings.Split(config.DockerComposeImage, ":")[1],
+						},
+					},
+					Run: atc.TaskRunConfig{
+						Path: "/bin/sh",
+						Dir:  gitDir + "/base.path",
+						Args: runScriptArgs(dockerComposeScript("app", expectedVars, "/usr/bin/a-command"), "", nil, "../.git/ref"),
 					},
 					Inputs: []atc.TaskInputConfig{
 						{Name: gitDir},


### PR DESCRIPTION
This PR adds support for overriding the docker-compose command via a `command` property of the docker-compose task.

Be gentle; it's my first Golang in anger 😛 

This supports https://ee-discourse.springernature.io/t/allow-user-to-specify-command-for-a-docker-compose-task/582/2