### PR TITLE
Env var

### DIFF
--- a/.pipeline.yml
+++ b/.pipeline.yml
@@ -118,7 +118,9 @@ jobs:
           export VERSION="$(cat version/version)"
           export CONF_PKG="github.com/springernature/halfpipe/config"
           export LDFLAGS="-X ${CONF_PKG}.Version=${VERSION}"
-          export LDFLAGS="${LDFLAGS} -X ${CONF_PKG}.SlackWebhook=((slack.webhook))"
+          if ! [[ -z "${SLACK_WEBHOOK:-}" ]]; then
+              export LDFLAGS="${LDFLAGS} -X ${CONF_PKG}.SlackWebhook=${SLACK_WEBHOOK}"
+          fi
           echo "LDFLAGS=${LDFLAGS}"
 
           # Build binaries

--- a/.pipeline.yml
+++ b/.pipeline.yml
@@ -118,7 +118,7 @@ jobs:
           export VERSION="$(cat version/version)"
           export CONF_PKG="github.com/springernature/halfpipe/config"
           export LDFLAGS="-X ${CONF_PKG}.Version=${VERSION}"
-          export LDFLAGS="${LDFLAGS} -X ${CONF_PKG}.SlackWebhook=https://hooks.slack.com/services/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"
+          export LDFLAGS="${LDFLAGS} -X ${CONF_PKG}.SlackWebhook=((slack.webhook))"
           echo "LDFLAGS=${LDFLAGS}"
 
           # Build binaries

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,9 @@ go test $go_opts -cover ./...
 echo [3/5] build
 CONF_PKG="github.com/springernature/halfpipe/config"
 LDFLAGS="-X ${CONF_PKG}.DocHost=docs.halfpipe.io"
-LDFLAGS="${LDFLAGS} -X ${CONF_PKG}.SlackWebhook=https://hooks.slack.com/services/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"
+if ! [[ -z "${SLACK_WEBHOOK:-}" ]]; then
+    LDFLAGS="${LDFLAGS} -X ${CONF_PKG}.SlackWebhook=${SLACK_WEBHOOK}"
+fi
 go build $go_opts -ldflags "${LDFLAGS}" cmd/halfpipe.go
 
 echo [4/5] e2e test

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 var (
 	Version = "0.0.0-DEV"
 
-	SlackWebhook = "Set your slack webhook here"
+	SlackWebhook = "((slack.webhook))"
 
 	DockerRegistry = "eu.gcr.io/halfpipe-io/"
 

--- a/e2e/notifications/expected-pipeline.yml
+++ b/e2e/notifications/expected-pipeline.yml
@@ -12,7 +12,7 @@ resources:
 - name: slack-notification
   type: slack-notification
   source:
-    url: https://hooks.slack.com/services/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
+    url: ((slack.webhook))
 - name: CF live pe staging
   type: cf-resource
   source:

--- a/e2e/update-pipeline/expected-pipeline.yml
+++ b/e2e/update-pipeline/expected-pipeline.yml
@@ -12,7 +12,7 @@ resources:
 - name: slack-notification
   type: slack-notification
   source:
-    url: https://hooks.slack.com/services/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
+    url: ((slack.webhook))
 - name: artifacts-engineering-enablement-test
   type: gcp-resource
   source:

--- a/e2e/versioned/expected-pipeline.yml
+++ b/e2e/versioned/expected-pipeline.yml
@@ -12,7 +12,7 @@ resources:
 - name: slack-notification
   type: slack-notification
   source:
-    url: https://hooks.slack.com/services/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
+    url: ((slack.webhook))
 - name: artifacts-engineering-enablement-test
   type: gcp-resource
   source:


### PR DESCRIPTION
Changed build.sh to respect environment variable `SLACK_WEBHOOK`. If it is not set then webhook url is defined in `configs.go` as vault variable `((slack.webhook))`. 
Please set up the vault variable.
@simonjohansson