### PR TITLE
Use BuildPath also when having restore_artifacts enabled

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -668,7 +668,7 @@ func dockerPushJobWithRestoreArtifacts(task manifest.DockerPush, resourceName st
 				Attempts: task.GetAttempts(),
 				Put:      resourceName,
 				Params: atc.Params{
-					"build":         path.Join(dockerBuildTmpDir, man.Repo.BasePath),
+					"build":         path.Join(dockerBuildTmpDir, man.Repo.BasePath, task.BuildPath),
 					"dockerfile":    path.Join(dockerBuildTmpDir, man.Repo.BasePath, task.DockerfilePath),
 					"tag_as_latest": true,
 				}},

--- a/pipeline/task_dockerpush_test.go
+++ b/pipeline/task_dockerpush_test.go
@@ -177,6 +177,8 @@ func TestRenderDockerPushWithVersioning(t *testing.T) {
 
 func TestRenderDockerPushWithVersioningAndRestoreArtifact(t *testing.T) {
 	basePath := "subapp/sub2"
+	buildPath := "build/path"
+
 	man := manifest.Manifest{
 		Repo: manifest.Repo{
 			URI:      "git@github.com:/springernature/foo.git",
@@ -197,6 +199,7 @@ func TestRenderDockerPushWithVersioningAndRestoreArtifact(t *testing.T) {
 			Image:            repo,
 			RestoreArtifacts: true,
 			DockerfilePath:   "Dockerfile",
+			BuildPath:        buildPath,
 		},
 	}
 
@@ -251,7 +254,7 @@ func TestRenderDockerPushWithVersioningAndRestoreArtifact(t *testing.T) {
 				Put:      "Docker Registry",
 				Params: atc.Params{
 					"tag_file":      "version/number",
-					"build":         dockerBuildTmpDir + "/" + basePath,
+					"build":         dockerBuildTmpDir + "/" + basePath + "/" + buildPath,
 					"dockerfile":    path.Join(dockerBuildTmpDir, man.Repo.BasePath, man.Tasks[0].(manifest.DockerPush).DockerfilePath),
 					"tag_as_latest": true,
 				}},


### PR DESCRIPTION
When having "restore_artifacts" enabled in a docker push task, the "build_path" is currently being ignored