### PR TITLE
Stop reading at newlines when reading response to prompt

### DIFF
--- a/upload/plan.go
+++ b/upload/plan.go
@@ -29,7 +29,7 @@ func (p Plan) Execute(stdout io.Writer, stderr io.Writer, stdin io.Reader, nonIn
 	if !nonInteractive {
 		fmt.Fprint(stdout, "\nAre you sure? [y/N]: ") // #nosec
 		var input string
-		fmt.Fscan(stdin, &input) // #nosec
+		fmt.Fscanln(stdin, &input) // #nosec
 		if input != "y" {
 			err = errors.New("aborted")
 			return


### PR DESCRIPTION
When you do `halfpipe upload`, it shows you the planned execution and then says `Are you sure? [y/N]:`. In the current implementation, if I press enter at that point, nothing happens. I need to enter at least one other character before pressing enter for it to actually abort (or just do Control-C).

This tiny commit should fix that -- it stops reading when encountering a newline in response to this prompt.