### PR TITLE
Allow suppression of missing bash warning

### DIFF
--- a/e2e/artifacts/expected-pipeline.yml
+++ b/e2e/artifacts/expected-pipeline.yml
@@ -93,8 +93,7 @@ jobs:
         args:
         - -c
         - |-
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -215,8 +214,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -353,8 +351,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
@@ -660,8 +657,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/artifacts/expected-pipeline.yml
+++ b/e2e/artifacts/expected-pipeline.yml
@@ -98,7 +98,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -220,7 +220,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -358,7 +358,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi
@@ -665,7 +665,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/artifacts/expected-pipeline.yml
+++ b/e2e/artifacts/expected-pipeline.yml
@@ -93,11 +93,12 @@ jobs:
         args:
         - -c
         - |-
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -214,11 +215,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -351,11 +353,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi
@@ -657,11 +660,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/deploy-cf-docker-image/expected-pipeline.yml
+++ b/e2e/deploy-cf-docker-image/expected-pipeline.yml
@@ -224,8 +224,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
@@ -364,8 +363,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"

--- a/e2e/deploy-cf-docker-image/expected-pipeline.yml
+++ b/e2e/deploy-cf-docker-image/expected-pipeline.yml
@@ -224,11 +224,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi
@@ -363,11 +364,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf-docker-image/expected-pipeline.yml
+++ b/e2e/deploy-cf-docker-image/expected-pipeline.yml
@@ -229,7 +229,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi
@@ -369,7 +369,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf-old-resource/expected-pipeline.yml
+++ b/e2e/deploy-cf-old-resource/expected-pipeline.yml
@@ -150,8 +150,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"

--- a/e2e/deploy-cf-old-resource/expected-pipeline.yml
+++ b/e2e/deploy-cf-old-resource/expected-pipeline.yml
@@ -155,7 +155,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf-old-resource/expected-pipeline.yml
+++ b/e2e/deploy-cf-old-resource/expected-pipeline.yml
@@ -150,11 +150,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf-rolling/expected-pipeline.yml
+++ b/e2e/deploy-cf-rolling/expected-pipeline.yml
@@ -101,11 +101,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf-rolling/expected-pipeline.yml
+++ b/e2e/deploy-cf-rolling/expected-pipeline.yml
@@ -101,8 +101,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"

--- a/e2e/deploy-cf-rolling/expected-pipeline.yml
+++ b/e2e/deploy-cf-rolling/expected-pipeline.yml
@@ -106,7 +106,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf/expected-pipeline.yml
+++ b/e2e/deploy-cf/expected-pipeline.yml
@@ -150,8 +150,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"

--- a/e2e/deploy-cf/expected-pipeline.yml
+++ b/e2e/deploy-cf/expected-pipeline.yml
@@ -155,7 +155,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-cf/expected-pipeline.yml
+++ b/e2e/deploy-cf/expected-pipeline.yml
@@ -150,11 +150,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/deploy-ml-modules/expected-pipeline.yml
+++ b/e2e/deploy-ml-modules/expected-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/deploy-ml-modules/expected-pipeline.yml
+++ b/e2e/deploy-ml-modules/expected-pipeline.yml
@@ -47,11 +47,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/deploy-ml-modules/expected-pipeline.yml
+++ b/e2e/deploy-ml-modules/expected-pipeline.yml
@@ -47,8 +47,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/deploy-ml-zip/expected-pipeline.yml
+++ b/e2e/deploy-ml-zip/expected-pipeline.yml
@@ -54,11 +54,12 @@ jobs:
         args:
         - -c
         - |-
-          if ! which bash > /dev/null; then
+            if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -175,11 +176,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/deploy-ml-zip/expected-pipeline.yml
+++ b/e2e/deploy-ml-zip/expected-pipeline.yml
@@ -54,8 +54,7 @@ jobs:
         args:
         - -c
         - |-
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -176,8 +175,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/deploy-ml-zip/expected-pipeline.yml
+++ b/e2e/deploy-ml-zip/expected-pipeline.yml
@@ -59,7 +59,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -181,7 +181,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/docker-decompose-feature/expected-pipeline.yml
+++ b/e2e/docker-decompose-feature/expected-pipeline.yml
@@ -61,7 +61,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -229,7 +229,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/docker-decompose-feature/expected-pipeline.yml
+++ b/e2e/docker-decompose-feature/expected-pipeline.yml
@@ -56,8 +56,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -224,8 +223,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"

--- a/e2e/docker-decompose-feature/expected-pipeline.yml
+++ b/e2e/docker-decompose-feature/expected-pipeline.yml
@@ -56,11 +56,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -223,11 +224,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/manual-git-trigger/expected-pipeline.yml
+++ b/e2e/manual-git-trigger/expected-pipeline.yml
@@ -41,7 +41,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/manual-git-trigger/expected-pipeline.yml
+++ b/e2e/manual-git-trigger/expected-pipeline.yml
@@ -36,11 +36,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/manual-git-trigger/expected-pipeline.yml
+++ b/e2e/manual-git-trigger/expected-pipeline.yml
@@ -36,8 +36,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/notifications/expected-pipeline.yml
+++ b/e2e/notifications/expected-pipeline.yml
@@ -86,11 +86,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -182,11 +183,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -308,11 +310,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/notifications/expected-pipeline.yml
+++ b/e2e/notifications/expected-pipeline.yml
@@ -91,7 +91,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -188,7 +188,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -315,7 +315,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi

--- a/e2e/notifications/expected-pipeline.yml
+++ b/e2e/notifications/expected-pipeline.yml
@@ -86,8 +86,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -183,8 +182,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -310,8 +308,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"

--- a/e2e/parallel/expected-pipeline.yml
+++ b/e2e/parallel/expected-pipeline.yml
@@ -99,11 +99,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -174,11 +175,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -249,11 +251,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -324,11 +327,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -403,11 +407,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -478,11 +483,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -557,11 +563,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -632,11 +639,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -707,11 +715,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -786,11 +795,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -865,11 +875,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/parallel/expected-pipeline.yml
+++ b/e2e/parallel/expected-pipeline.yml
@@ -104,7 +104,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -180,7 +180,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -256,7 +256,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -332,7 +332,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -412,7 +412,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -488,7 +488,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -568,7 +568,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -644,7 +644,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -720,7 +720,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -800,7 +800,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -880,7 +880,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/parallel/expected-pipeline.yml
+++ b/e2e/parallel/expected-pipeline.yml
@@ -99,8 +99,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -175,8 +174,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -251,8 +249,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -327,8 +324,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -407,8 +403,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -483,8 +478,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -563,8 +557,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -639,8 +632,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -715,8 +707,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -795,8 +786,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -875,8 +865,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/run/expected-pipeline.yml
+++ b/e2e/run/expected-pipeline.yml
@@ -47,7 +47,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/run/expected-pipeline.yml
+++ b/e2e/run/expected-pipeline.yml
@@ -42,11 +42,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/run/expected-pipeline.yml
+++ b/e2e/run/expected-pipeline.yml
@@ -42,8 +42,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/update-pipeline/expected-pipeline.yml
+++ b/e2e/update-pipeline/expected-pipeline.yml
@@ -167,8 +167,7 @@ jobs:
         args:
         - -c
         - |-
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -424,8 +423,7 @@ jobs:
               args:
               - -c
               - |
-                which bash > /dev/null
-                if [ $? != 0 ]; then
+                if ! which bash > /dev/null; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
@@ -668,8 +666,7 @@ jobs:
           args:
           - -c
           - |-
-            which bash > /dev/null
-            if [ $? != 0 ]; then
+            if ! which bash > /dev/null; then
               echo "WARNING: Bash is not present in the docker image"
               echo "If your script depends on bash you will get a strange error message like:"
               echo "  sh: yourscript.sh: command not found"
@@ -751,8 +748,7 @@ jobs:
           args:
           - -c
           - |
-            which bash > /dev/null
-            if [ $? != 0 ]; then
+            if ! which bash > /dev/null; then
               echo "WARNING: Bash is not present in the docker image"
               echo "If your script depends on bash you will get a strange error message like:"
               echo "  sh: yourscript.sh: command not found"
@@ -878,8 +874,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -1192,8 +1187,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
@@ -1278,8 +1272,7 @@ jobs:
         args:
         - -c
         - |
-          which bash > /dev/null
-          if [ $? != 0 ]; then
+          if ! which bash > /dev/null; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"

--- a/e2e/update-pipeline/expected-pipeline.yml
+++ b/e2e/update-pipeline/expected-pipeline.yml
@@ -172,7 +172,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -429,7 +429,7 @@ jobs:
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
-                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
                   echo ""
                   echo ""
                 fi
@@ -673,7 +673,7 @@ jobs:
               echo "If your script depends on bash you will get a strange error message like:"
               echo "  sh: yourscript.sh: command not found"
               echo "To fix, make sure your docker image contains bash!"
-              echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+              echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
               echo ""
               echo ""
             fi
@@ -756,7 +756,7 @@ jobs:
               echo "If your script depends on bash you will get a strange error message like:"
               echo "  sh: yourscript.sh: command not found"
               echo "To fix, make sure your docker image contains bash!"
-              echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+              echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
               echo ""
               echo ""
             fi
@@ -883,7 +883,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -1197,7 +1197,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi
@@ -1283,7 +1283,7 @@ jobs:
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
-            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
             echo ""
             echo ""
           fi

--- a/e2e/update-pipeline/expected-pipeline.yml
+++ b/e2e/update-pipeline/expected-pipeline.yml
@@ -167,11 +167,12 @@ jobs:
         args:
         - -c
         - |-
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -423,11 +424,12 @@ jobs:
               args:
               - -c
               - |
-                if ! which bash > /dev/null; then
+                if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
                   echo "WARNING: Bash is not present in the docker image"
                   echo "If your script depends on bash you will get a strange error message like:"
                   echo "  sh: yourscript.sh: command not found"
                   echo "To fix, make sure your docker image contains bash!"
+                  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
                   echo ""
                   echo ""
                 fi
@@ -666,11 +668,12 @@ jobs:
           args:
           - -c
           - |-
-            if ! which bash > /dev/null; then
+            if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
               echo "WARNING: Bash is not present in the docker image"
               echo "If your script depends on bash you will get a strange error message like:"
               echo "  sh: yourscript.sh: command not found"
               echo "To fix, make sure your docker image contains bash!"
+              echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
               echo ""
               echo ""
             fi
@@ -748,11 +751,12 @@ jobs:
           args:
           - -c
           - |
-            if ! which bash > /dev/null; then
+            if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
               echo "WARNING: Bash is not present in the docker image"
               echo "If your script depends on bash you will get a strange error message like:"
               echo "  sh: yourscript.sh: command not found"
               echo "To fix, make sure your docker image contains bash!"
+              echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
               echo ""
               echo ""
             fi
@@ -874,11 +878,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -1187,11 +1192,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi
@@ -1272,11 +1278,12 @@ jobs:
         args:
         - -c
         - |
-          if ! which bash > /dev/null; then
+          if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
             echo "WARNING: Bash is not present in the docker image"
             echo "If your script depends on bash you will get a strange error message like:"
             echo "  sh: yourscript.sh: command not found"
             echo "To fix, make sure your docker image contains bash!"
+            echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
             echo ""
             echo ""
           fi

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1015,7 +1015,7 @@ func runScriptArgs(task manifest.Run, man manifest.Manifest, checkForBash bool, 
   echo "If your script depends on bash you will get a strange error message like:"
   echo "  sh: yourscript.sh: command not found"
   echo "To fix, make sure your docker image contains bash!"
-  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
+  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING\" to \"true\"."
   echo ""
   echo ""
 fi

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1010,11 +1010,12 @@ func runScriptArgs(task manifest.Run, man manifest.Manifest, checkForBash bool, 
 	var out []string
 
 	if checkForBash {
-		out = append(out, `if ! which bash > /dev/null; then
+		out = append(out, `if ! which bash > /dev/null && [ "$SUPPRESS_BASH_WARNING" != "true" ]; then
   echo "WARNING: Bash is not present in the docker image"
   echo "If your script depends on bash you will get a strange error message like:"
   echo "  sh: yourscript.sh: command not found"
   echo "To fix, make sure your docker image contains bash!"
+  echo "Or if you are sure you don't need bash you can suppress this warning by setting the environment variable \"SUPPRESS_BASH_WARNING" to \"true\"."
   echo ""
   echo ""
 fi

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1010,8 +1010,7 @@ func runScriptArgs(task manifest.Run, man manifest.Manifest, checkForBash bool, 
 	var out []string
 
 	if checkForBash {
-		out = append(out, `which bash > /dev/null
-if [ $? != 0 ]; then
+		out = append(out, `if ! which bash > /dev/null; then
   echo "WARNING: Bash is not present in the docker image"
   echo "If your script depends on bash you will get a strange error message like:"
   echo "  sh: yourscript.sh: command not found"


### PR DESCRIPTION
E.g in https://concourse.halfpipe.io/teams/srs/pipelines/grafana/jobs/create-dashboards/builds/4.1 we get this warning:

> WARNING: Bash is not present in the docker image
If your script depends on bash you will get a strange error message like:
  sh: yourscript.sh: command not found
To fix, make sure your docker image contains bash!

This pull request adds an environment variable to suppress this warning.

The warning message will be appended with information about this:

>WARNING: Bash is not present in the docker image
If your script depends on bash you will get a strange error message like:
  sh: yourscript.sh: command not found
To fix, make sure your docker image contains bash!
Or if you are sure you don't need bash you can suppress this warning by setting the environment variable "SUPPRESS_BASH_WARNING" to "true".

**Please note**: this is untested, as I don't have go installed. :-)