### PR TITLE
Allow to customise slack messages for whole pipeline

### DIFF
--- a/e2e/actions/notifications/.halfpipe.io
+++ b/e2e/actions/notifications/.halfpipe.io
@@ -1,5 +1,6 @@
 team: halfpipe-team
 pipeline: pipeline-name
+slack_failure_message: failure msg
 
 tasks:
 - type: run
@@ -14,4 +15,3 @@ tasks:
     on_success_message: success message
     on_failure:
     - '#failure1'
-    on_failure_message: failure message

--- a/e2e/actions/notifications/workflowExpected.yml
+++ b/e2e/actions/notifications/workflowExpected.yml
@@ -40,7 +40,7 @@ jobs:
         status: ${{ job.status }}
         oauth_token: ${{ secrets.EE_SLACK_TOKEN }}
         channel: '#failure1'
-        text: failure message
+        text: failure msg
     - name: 'Notify slack #success1 (success)'
       uses: yukin01/slack-bot-action@v0.0.4
       with:

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -155,13 +155,15 @@ func (t TriggerList) HasGitTrigger() bool {
 }
 
 type Manifest struct {
-	Team           string         `yaml:"team,omitempty"`
-	Pipeline       string         `yaml:"pipeline,omitempty"`
-	SlackChannel   string         `json:"slack_channel,omitempty" yaml:"slack_channel,omitempty"`
-	ArtifactConfig ArtifactConfig `json:"artifact_config,omitempty" yaml:"artifact_config,omitempty"`
-	FeatureToggles FeatureToggles `json:"feature_toggles,omitempty" yaml:"feature_toggles,omitempty"`
-	Triggers       TriggerList    `json:"triggers,omitempty" yaml:"triggers,omitempty"`
-	Tasks          TaskList       `yaml:"tasks,omitempty"`
+	Team                string         `yaml:"team,omitempty"`
+	Pipeline            string         `yaml:"pipeline,omitempty"`
+	SlackChannel        string         `json:"slack_channel,omitempty" yaml:"slack_channel,omitempty"`
+	SlackSuccessMessage string         `json:"slack_success_message,omitempty" yaml:"slack_success_message,omitempty"`
+	SlackFailureMessage string         `json:"slack_failure_message,omitempty" yaml:"slack_failure_message,omitempty"`
+	ArtifactConfig      ArtifactConfig `json:"artifact_config,omitempty" yaml:"artifact_config,omitempty"`
+	FeatureToggles      FeatureToggles `json:"feature_toggles,omitempty" yaml:"feature_toggles,omitempty"`
+	Triggers            TriggerList    `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	Tasks               TaskList       `yaml:"tasks,omitempty"`
 }
 
 func (m Manifest) PipelineName() (pipelineName string) {

--- a/manifest/parser_test.go
+++ b/manifest/parser_test.go
@@ -19,6 +19,8 @@ func TestValidYaml_Everything(t *testing.T) {
 team: my team
 pipeline: my pipeline
 slack_channel: "#ee-activity"
+slack_success_message: "success"
+slack_failure_message: "failure"
 artifact_config:
   bucket: myBucket
   json_key: ((some.jsonKey))
@@ -178,7 +180,9 @@ tasks:
 			Bucket:  "myBucket",
 			JSONKey: "((some.jsonKey))",
 		},
-		SlackChannel: "#ee-activity",
+		SlackChannel:        "#ee-activity",
+		SlackSuccessMessage: "success",
+		SlackFailureMessage: "failure",
 		FeatureToggles: FeatureToggles{
 			"feature1",
 			"feature2",

--- a/mapper/notifications.go
+++ b/mapper/notifications.go
@@ -5,14 +5,14 @@ import "github.com/springernature/halfpipe/manifest"
 type notificationsMapper struct {
 }
 
-func (n notificationsMapper) updateTasks(tasks manifest.TaskList, slackChannel string) (updated manifest.TaskList) {
+func (n notificationsMapper) updateTasks(tasks manifest.TaskList, slackChannel string, slackSuccessMessage string, slackFailureMessage string) (updated manifest.TaskList) {
 	for _, task := range tasks {
 		switch task := task.(type) {
 		case manifest.Parallel:
-			task.Tasks = n.updateTasks(task.Tasks, slackChannel)
+			task.Tasks = n.updateTasks(task.Tasks, slackChannel, slackSuccessMessage, slackFailureMessage)
 			updated = append(updated, task)
 		case manifest.Sequence:
-			task.Tasks = n.updateTasks(task.Tasks, slackChannel)
+			task.Tasks = n.updateTasks(task.Tasks, slackChannel, slackSuccessMessage, slackFailureMessage)
 			updated = append(updated, task)
 		default:
 			if !task.GetNotifications().NotificationsDefined() {
@@ -26,17 +26,31 @@ func (n notificationsMapper) updateTasks(tasks manifest.TaskList, slackChannel s
 				task = task.SetNotifications(notifications)
 			}
 
+			task = updateMessages(task, slackSuccessMessage, slackFailureMessage)
+
 			updated = append(updated, task)
 		}
 	}
 	return updated
 }
 
+func updateMessages(task manifest.Task, slackSuccessMessage string, slackFailureMessage string) manifest.Task {
+	notifications := task.GetNotifications()
+	if len(notifications.OnSuccess) > 0 && notifications.OnSuccessMessage == "" && slackSuccessMessage != "" {
+		notifications.OnSuccessMessage = slackSuccessMessage
+	}
+	if notifications.OnFailureMessage == "" && slackFailureMessage != "" {
+		notifications.OnFailureMessage = slackFailureMessage
+	}
+	task = task.SetNotifications(notifications)
+	return task
+}
+
 func (n notificationsMapper) Apply(original manifest.Manifest) (updated manifest.Manifest, err error) {
 	updated = original
 
 	if updated.SlackChannel != "" {
-		updated.Tasks = n.updateTasks(updated.Tasks, updated.SlackChannel)
+		updated.Tasks = n.updateTasks(updated.Tasks, updated.SlackChannel, updated.SlackSuccessMessage, updated.SlackFailureMessage)
 		updated.SlackChannel = ""
 	}
 

--- a/mapper/notifications_test.go
+++ b/mapper/notifications_test.go
@@ -192,3 +192,35 @@ func TestUpdatesNotificationsWhenSlackChannelIsDefined(t *testing.T) {
 		assert.Equal(t, expected, updated)
 	})
 }
+
+func TestDefaultNotificationMessages(t *testing.T) {
+	defaultFailureMessage := "failure msg"
+	defaultSuccessMessage := "success msg"
+
+	input := manifest.Manifest{
+		SlackChannel:        "#test",
+		SlackFailureMessage: defaultFailureMessage,
+		SlackSuccessMessage: defaultSuccessMessage,
+		Tasks: manifest.TaskList{
+			manifest.Run{},
+			manifest.DockerPush{},
+			manifest.DeployCF{
+				Notifications: manifest.Notifications{
+					OnSuccess:        []string{"#foo"},
+					OnSuccessMessage: "custom",
+					OnFailureMessage: "custom",
+				},
+			},
+		},
+	}
+
+	updated, _ := NewNotificationsMapper().Apply(input)
+	assert.Equal(t, defaultFailureMessage, updated.Tasks[0].GetNotifications().OnFailureMessage)
+	assert.Equal(t, defaultFailureMessage, updated.Tasks[1].GetNotifications().OnFailureMessage)
+	assert.Equal(t, "custom", updated.Tasks[2].GetNotifications().OnFailureMessage)
+
+	assert.Equal(t, defaultSuccessMessage, updated.Tasks[0].GetNotifications().OnSuccessMessage)
+	assert.Equal(t, defaultSuccessMessage, updated.Tasks[1].GetNotifications().OnSuccessMessage)
+	assert.Equal(t, "custom", updated.Tasks[2].GetNotifications().OnFailureMessage)
+
+}


### PR DESCRIPTION
Two new attributes on top level to be able to overwrite the slack messages.

Example:

    team: my-team
    pipeline: my-pipeline
    slack_channel: "#my-slack-channel"
    slack_success_message: ":ok: <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|$BUILD_PIPELINE_NAME / $BUILD_JOB_NAME / build $BUILD_NAME> succeeded"
    slack_failure_message: ":redsiren: <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|$BUILD_PIPELINE_NAME / $BUILD_JOB_NAME / build $BUILD_NAME> failed"

generates:


    on_failure:
      attempts: 2
      params:
        channel: '#my-slack-channel'
        icon_url: https://concourse.halfpipe.io/public/images/favicon-failed.png
        text: ':redsiren: <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|$BUILD_PIPELINE_NAME
          / $BUILD_JOB_NAME / build $BUILD_NAME> failed'
        username: Halfpipe
      put: slack
      timeout: 15m
    on_success:
      attempts: 2
      params:
        channel: '#my-slack-channel'
        icon_url: https://concourse.halfpipe.io/public/images/favicon-succeeded.png
        text: ':ok: <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|$BUILD_PIPELINE_NAME
          / $BUILD_JOB_NAME / build $BUILD_NAME> succeeded'
        username: Halfpipe
      put: slack
      timeout: 15m
