### PR TITLE
Fixed typo in Actions fetch-depth output

### DIFF
--- a/e2e/actions/trigger-git-shallow/workflowExpected.yml
+++ b/e2e/actions/trigger-git-shallow/workflowExpected.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
-        fetch_depth: 0
+        fetch-depth: 0
     - name: run \date
       uses: docker://alpine
       with:
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
-        fetch_depth: 0
+        fetch-depth: 0
     - name: run \date (1)
       uses: docker://alpine
       with:

--- a/renderers/actions/actions.go
+++ b/renderers/actions/actions.go
@@ -114,7 +114,7 @@ func checkoutCode(gitTrigger manifest.GitTrigger) Step {
 		Uses: "actions/checkout@v2",
 	}
 	if !gitTrigger.Shallow {
-		checkout.With = With{{"fetch_depth", 0}}
+		checkout.With = With{{"fetch-depth", 0}}
 	}
 	return checkout
 }


### PR DESCRIPTION
This fixes a transposition of - with _ in the current actions output.

```
Unexpected input(s) 'fetch_depth', valid inputs are ['repository', 'ref', 'token', 'ssh-key', 'ssh-known-hosts', 'ssh-strict', 'persist-credentials', 'path', 'clean', 'fetch-depth', 'lfs', 'submodules'] 
```
https://github.com/springernature/big-brother/actions/runs/574604416