### PR TITLE
Allow to specify an input filename to allow several GitHub Actions files per source code folder

### DIFF
--- a/cmd/cmds/actions-migration-help.go
+++ b/cmd/cmds/actions-migration-help.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/springernature/halfpipe/config"
 	"github.com/springernature/halfpipe/migrate"
 )
 
@@ -13,7 +14,7 @@ var actionsMigrationHelp = &cobra.Command{
 	Use:   "actions-migration-help",
 	Short: "Prints out the steps needed to migrate from Concourse to Actions",
 	Run: func(cmd *cobra.Command, args []string) {
-		man, controller := getManifestAndController()
+		man, controller := getManifestAndController(config.HalfpipeFilenameOptions)
 		response := controller.Process(man)
 
 		migrate.ActionsMigrationHelper(man, response)

--- a/cmd/cmds/helpers.go
+++ b/cmd/cmds/helpers.go
@@ -130,7 +130,7 @@ func createController(projectData project.Data, fs afero.Afero, currentDir strin
 
 }
 
-func getManifestAndController() (manifest.Manifest, halfpipe.Controller) {
+func getManifestAndController(halfpipeFilenameOptions []string) (manifest.Manifest, halfpipe.Controller) {
 	if err := checkVersion(); err != nil {
 		printErr(err)
 		os.Exit(1)
@@ -144,7 +144,7 @@ func getManifestAndController() (manifest.Manifest, halfpipe.Controller) {
 		os.Exit(1)
 	}
 
-	projectData, err := project.NewProjectResolver(fs).Parse(currentDir, false)
+	projectData, err := project.NewProjectResolver(fs).Parse(currentDir, false, halfpipeFilenameOptions)
 	if err != nil {
 		printErr(err)
 		os.Exit(1)

--- a/cmd/cmds/internal-representation.go
+++ b/cmd/cmds/internal-representation.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/springernature/halfpipe/config"
 	"github.com/springernature/halfpipe/manifest"
 	"gopkg.in/yaml.v2"
 )
@@ -22,7 +23,7 @@ var internalRepresentation = &cobra.Command{
 	Short: `Prints the internal representation of the manifest`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		man, controller := getManifestAndController()
+		man, controller := getManifestAndController(config.HalfpipeFilenameOptions)
 
 		defaultedAndMappedManifest, _ := controller.DefaultAndMap(man)
 

--- a/cmd/cmds/migrate.go
+++ b/cmd/cmds/migrate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/springernature/halfpipe/config"
 	"github.com/springernature/halfpipe/linters/result"
 	"github.com/springernature/halfpipe/manifest"
 	"github.com/springernature/halfpipe/migrate"
@@ -33,7 +34,7 @@ var migrateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		projectData, err := project.NewProjectResolver(fs).Parse(currentDir, false)
+		projectData, err := project.NewProjectResolver(fs).Parse(currentDir, false, config.HalfpipeFilenameOptions)
 		if err != nil {
 			printErr(err)
 			os.Exit(1)

--- a/cmd/cmds/pipeline_name.go
+++ b/cmd/cmds/pipeline_name.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"fmt"
+	"github.com/springernature/halfpipe/config"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -15,7 +16,7 @@ var pipelineNameCmd = &cobra.Command{
 	Use:   "pipeline-name",
 	Short: "Prints the name of the pipeline",
 	Run: func(cmd *cobra.Command, args []string) {
-		man, _ := getManifestAndController()
+		man, _ := getManifestAndController(config.HalfpipeFilenameOptions)
 		if man.PipelineName() == "" {
 			os.Exit(1)
 		}

--- a/cmd/cmds/root.go
+++ b/cmd/cmds/root.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"github.com/springernature/halfpipe/config"
 	"os"
 	"path"
 
@@ -12,7 +13,13 @@ var rootCmd = &cobra.Command{
 	Short: `halfpipe is a tool to lint and render pipelines
 Invoke without any arguments to lint your .halfpipe.io file and render a pipeline`,
 	Run: func(cmd *cobra.Command, args []string) {
-		man, controller := getManifestAndController()
+		var halfpipeFilenameOptions []string
+		if input == "" {
+			halfpipeFilenameOptions = config.HalfpipeFilenameOptions
+		} else {
+			halfpipeFilenameOptions = []string{input}
+		}
+		man, controller := getManifestAndController(halfpipeFilenameOptions)
 		response := controller.Process(man)
 
 		if man.Platform.IsActions() && output == "" {
@@ -23,9 +30,11 @@ Invoke without any arguments to lint your .halfpipe.io file and render a pipelin
 	},
 }
 
+var input string
 var output string
 
 func Execute() {
+	rootCmd.Flags().StringVarP(&input, "input", "i", "", "Sets the halfpipe filename to be used")
 	rootCmd.Flags().StringVarP(&output, "output", "o", "", "Sets the path where the rendered pipeline will be saved to")
 	if err := rootCmd.Execute(); err != nil {
 		printErr(err)

--- a/cmd/cmds/url.go
+++ b/cmd/cmds/url.go
@@ -27,7 +27,7 @@ var urlCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		projectData, err := project.NewProjectResolver(fs).Parse(currentDir, false)
+		projectData, err := project.NewProjectResolver(fs).Parse(currentDir, false, config.HalfpipeFilenameOptions)
 		if err != nil {
 			printErr(err)
 			os.Exit(1)

--- a/linters/filechecker/filechecker.go
+++ b/linters/filechecker/filechecker.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	errors2 "github.com/pkg/errors"
 	"github.com/spf13/afero"
-	"github.com/springernature/halfpipe/config"
 	"github.com/springernature/halfpipe/linters/linterrors"
 	"path"
 )
@@ -48,10 +47,10 @@ func ReadFile(fs afero.Afero, path string) (content string, err error) {
 	return content, err
 }
 
-func GetHalfpipeFileName(fs afero.Afero, workingDir string) (halfpipeFileName string, err error) {
+func GetHalfpipeFileName(fs afero.Afero, workingDir string, halfpipeFilenameOptions []string) (halfpipeFileName string, err error) {
 	var foundPaths []string
 
-	for _, p := range config.HalfpipeFilenameOptions {
+	for _, p := range halfpipeFilenameOptions {
 		joinedPath := path.Join(workingDir, p)
 		if exists, fileNotExistErr := fs.Exists(joinedPath); exists && fileNotExistErr == nil {
 			foundPaths = append(foundPaths, p)
@@ -64,7 +63,7 @@ func GetHalfpipeFileName(fs afero.Afero, workingDir string) (halfpipeFileName st
 	}
 
 	if len(foundPaths) == 0 {
-		err = linterrors.NewMissingHalfpipeFileError()
+		err = linterrors.NewMissingHalfpipeFileError(halfpipeFilenameOptions)
 		return halfpipeFileName, err
 	}
 

--- a/linters/filechecker/filechecker_test.go
+++ b/linters/filechecker/filechecker_test.go
@@ -1,6 +1,7 @@
 package filechecker
 
 import (
+	"github.com/springernature/halfpipe/config"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -78,7 +79,7 @@ func TestReadHalfpipeFilesErrorsTwoFileOptionsExist(t *testing.T) {
 	fs.WriteFile(".halfpipe.io", []byte{}, 0700)
 	fs.WriteFile(".halfpipe.io.yml", []byte{}, 0700)
 
-	_, err := GetHalfpipeFileName(fs, "")
+	_, err := GetHalfpipeFileName(fs, "", config.HalfpipeFilenameOptions)
 
 	assert.EqualError(t, err, "found [.halfpipe.io .halfpipe.io.yml] files. Please use only 1 of those")
 }
@@ -86,14 +87,29 @@ func TestReadHalfpipeFilesErrorsTwoFileOptionsExist(t *testing.T) {
 func TestReadHalfpipeFilesErrorsWhenBothOptionsAreNotThere(t *testing.T) {
 	pr := testFs()
 
-	_, err := GetHalfpipeFileName(pr, "")
+	_, err := GetHalfpipeFileName(pr, "", config.HalfpipeFilenameOptions)
 
 	assert.EqualError(t, err, "couldn't find any of the allowed [.halfpipe.io .halfpipe.io.yml .halfpipe.io.yaml] files")
+}
+
+func TestReadHalfpipeFilesErrorsWhenExplicitFilenameGivenButFIleIsMissing(t *testing.T) {
+	pr := testFs()
+
+	_, err := GetHalfpipeFileName(pr, "", []string{"some-other-file.yml"})
+
+	assert.EqualError(t, err, "couldn't find any of the allowed [some-other-file.yml] files")
 }
 
 func TestReadHalfpipeFilesIsHappyWithOneOfTheOptions(t *testing.T) {
 	fs := testFs()
 	fs.WriteFile(".halfpipe.io", []byte("foo"), 0700)
-	_, err := GetHalfpipeFileName(fs, "")
+	_, err := GetHalfpipeFileName(fs, "", config.HalfpipeFilenameOptions)
+	assert.Nil(t, err)
+}
+
+func TestReadHalfpipeFilesIsHappyWithExplicitFilenameGiven(t *testing.T) {
+	fs := testFs()
+	fs.WriteFile("some-other-file.yml", []byte("foo"), 0700)
+	_, err := GetHalfpipeFileName(fs, "", []string{"some-other-file.yml"})
 	assert.Nil(t, err)
 }

--- a/linters/linterrors/missing_halfpipe_files_error.go
+++ b/linters/linterrors/missing_halfpipe_files_error.go
@@ -2,16 +2,18 @@ package linterrors
 
 import (
 	"fmt"
-	"github.com/springernature/halfpipe/config"
 )
 
 type MissingHalfpipeFileError struct {
+	HalfpipeFilenameOptions []string
 }
 
-func NewMissingHalfpipeFileError() MissingHalfpipeFileError {
-	return MissingHalfpipeFileError{}
+func NewMissingHalfpipeFileError(halfpipeFilenameOptions []string) MissingHalfpipeFileError {
+	return MissingHalfpipeFileError{
+		HalfpipeFilenameOptions: halfpipeFilenameOptions,
+	}
 }
 
 func (e MissingHalfpipeFileError) Error() string {
-	return fmt.Sprintf("couldn't find any of the allowed %s files", config.HalfpipeFilenameOptions)
+	return fmt.Sprintf("couldn't find any of the allowed %s files", e.HalfpipeFilenameOptions)
 }

--- a/manifest/sample_generator.go
+++ b/manifest/sample_generator.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"errors"
+	"github.com/springernature/halfpipe/config"
 
 	"fmt"
 	"strings"
@@ -57,7 +58,7 @@ func (s sampleGenerator) Generate() (err error) {
 		},
 	}
 
-	proj, err := s.projectResolver.Parse(s.currentDir, true)
+	proj, err := s.projectResolver.Parse(s.currentDir, true, config.HalfpipeFilenameOptions)
 	if err != nil {
 		return err
 	}

--- a/manifest/sample_generator_test.go
+++ b/manifest/sample_generator_test.go
@@ -14,7 +14,7 @@ type FakeProjectResolver struct {
 	err error
 }
 
-func (pr FakeProjectResolver) Parse(workingDir string, ignoreMissingHalfpipeFile bool) (p project.Data, err error) {
+func (pr FakeProjectResolver) Parse(workingDir string, ignoreMissingHalfpipeFile bool, halfpipeFilenameOptions []string) (p project.Data, err error) {
 	return pr.p, pr.err
 }
 

--- a/project/project.go
+++ b/project/project.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	errors2 "github.com/springernature/halfpipe/linters/linterrors"
 	"path/filepath"
 
 	"github.com/springernature/halfpipe/linters/filechecker"
@@ -96,11 +97,13 @@ func (c projectResolver) Parse(workingDir string, ignoreMissingHalfpipeFile bool
 
 	halfpipeFilePath, e := filechecker.GetHalfpipeFileName(c.Fs, workingDir, halfpipeFilenameOptions)
 	if e != nil {
-		// TODO fix this
-		//if !(e == errors2.NewMissingHalfpipeFileError() && ignoreMissingHalfpipeFile) {
-		//	err = e
-		//	return p, err
-		//}
+		switch e.(type) {
+		case errors2.MissingHalfpipeFileError:
+			if !ignoreMissingHalfpipeFile {
+				err = e
+				return p, err
+			}
+		}
 	}
 
 	p.GitURI = origin

--- a/project/project.go
+++ b/project/project.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/springernature/halfpipe/linters/filechecker"
-	errors2 "github.com/springernature/halfpipe/linters/linterrors"
+	//errors2 "github.com/springernature/halfpipe/linters/linterrors"
 
 	"os/exec"
 
@@ -24,7 +24,7 @@ type Data struct {
 }
 
 type Project interface {
-	Parse(workingDir string, ignoreMissingHalfpipeFile bool) (p Data, err error)
+	Parse(workingDir string, ignoreMissingHalfpipeFile bool, halfpipeFilenameOptions []string) (p Data, err error)
 }
 
 type projectResolver struct {
@@ -48,7 +48,7 @@ var (
 	ErrNoCommits          = errors.New("looks like you are executing halfpipe in a repo without commits, this is not supported")
 )
 
-func (c projectResolver) Parse(workingDir string, ignoreMissingHalfpipeFile bool) (p Data, err error) {
+func (c projectResolver) Parse(workingDir string, ignoreMissingHalfpipeFile bool, halfpipeFilenameOptions []string) (p Data, err error) {
 	var pathRelativeToGit func(string) (basePath string, rootName string, gitRootPath string, err error)
 
 	pathRelativeToGit = func(path string) (basePath string, rootName string, gitRootPath string, err error) {
@@ -94,12 +94,13 @@ func (c projectResolver) Parse(workingDir string, ignoreMissingHalfpipeFile bool
 		return p, err
 	}
 
-	halfpipeFilePath, e := filechecker.GetHalfpipeFileName(c.Fs, workingDir)
+	halfpipeFilePath, e := filechecker.GetHalfpipeFileName(c.Fs, workingDir, halfpipeFilenameOptions)
 	if e != nil {
-		if !(e == errors2.NewMissingHalfpipeFileError() && ignoreMissingHalfpipeFile) {
-			err = e
-			return p, err
-		}
+		// TODO fix this
+		//if !(e == errors2.NewMissingHalfpipeFileError() && ignoreMissingHalfpipeFile) {
+		//	err = e
+		//	return p, err
+		//}
 	}
 
 	p.GitURI = origin

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"github.com/springernature/halfpipe/config"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -20,14 +21,14 @@ func TestErrorsIfGitNotFoundOnPath(t *testing.T) {
 	pr := testProjectResolver()
 	pr.LookPath = func(string) (string, error) { return "", errors.New("dummy") }
 
-	_, err := pr.Parse("/project/root", false)
+	_, err := pr.Parse("/project/root", false, config.HalfpipeFilenameOptions)
 	assert.Equal(t, ErrGitNotFound, err)
 }
 
 func TestErrorsIfNotInGitRepo(t *testing.T) {
 	pr := testProjectResolver()
 
-	_, err := pr.Parse("/project/root", false)
+	_, err := pr.Parse("/project/root", false, config.HalfpipeFilenameOptions)
 	assert.Equal(t, ErrNotInRepo, err)
 }
 
@@ -36,7 +37,7 @@ func TestErrorsIfNoGitOriginConfigured(t *testing.T) {
 	pr.OriginURL = func() (string, error) { return "", errors.New("dummy") }
 	pr.Fs.MkdirAll("/project/root/.git", 0777)
 
-	_, err := pr.Parse("/project/root", false)
+	_, err := pr.Parse("/project/root", false, config.HalfpipeFilenameOptions)
 	assert.Equal(t, ErrNoOriginConfigured, err)
 }
 
@@ -45,7 +46,7 @@ func TestGetsGitData(t *testing.T) {
 	pr.Fs.MkdirAll("/project/root/.git", 0777)
 	pr.Fs.Create("/project/root/.halfpipe.io")
 
-	project, err := pr.Parse("/project/root", false)
+	project, err := pr.Parse("/project/root", false, config.HalfpipeFilenameOptions)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "git@origin", project.GitURI)
@@ -54,7 +55,7 @@ func TestGetsGitData(t *testing.T) {
 func TestErrorsOutIfStartPathCannotBeRead(t *testing.T) {
 	pr := testProjectResolver()
 
-	_, err := pr.Parse("/home/simon/src/repo", false)
+	_, err := pr.Parse("/home/simon/src/repo", false, config.HalfpipeFilenameOptions)
 	assert.Equal(t, ErrNotInRepo, err)
 }
 
@@ -75,7 +76,7 @@ func TestBasePathWhenInGitRepo(t *testing.T) {
 
 func assertBasePath(t *testing.T, pr projectResolver, workingDir string, expectedBasePath string) {
 	t.Helper()
-	project, err := pr.Parse(workingDir, false)
+	project, err := pr.Parse(workingDir, false, config.HalfpipeFilenameOptions)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedBasePath, project.BasePath)
 }
@@ -97,7 +98,7 @@ func TestRootNameWhenInGitRepo(t *testing.T) {
 
 func assertRootName(t *testing.T, pr projectResolver, workingDir string, expectedRootName string) {
 	t.Helper()
-	project, err := pr.Parse(workingDir, false)
+	project, err := pr.Parse(workingDir, false, config.HalfpipeFilenameOptions)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRootName, project.RootName)
 }
@@ -106,7 +107,7 @@ func TestErrorsOutIfWeReachRootWithoutFindingGit(t *testing.T) {
 	pr := testProjectResolver()
 	pr.Fs.MkdirAll("/home/simon/src/repo/a/b/c", 0777)
 
-	_, err := pr.Parse("/home/simon/src/repo/a/b/c", false)
+	_, err := pr.Parse("/home/simon/src/repo/a/b/c", false, config.HalfpipeFilenameOptions)
 	assert.Equal(t, ErrNotInRepo, err)
 }
 
@@ -116,7 +117,7 @@ func TestErrorsOutIfPassedDodgyPathValue(t *testing.T) {
 	paths := []string{"", "foo", "/..", ".."}
 
 	for _, path := range paths {
-		_, err := pr.Parse(path, false)
+		_, err := pr.Parse(path, false, config.HalfpipeFilenameOptions)
 		assert.Equal(t, ErrNotInRepo, err)
 	}
 }
@@ -125,7 +126,7 @@ func TestDoesntErrorOutIfHalfpipeFileIsMissing(t *testing.T) {
 	pr := testProjectResolver()
 	pr.Fs.MkdirAll("/project/root/.git", 0777)
 
-	project, err := pr.Parse("/project/root", true)
+	project, err := pr.Parse("/project/root", true, config.HalfpipeFilenameOptions)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "git@origin", project.GitURI)

--- a/upload/planner.go
+++ b/upload/planner.go
@@ -62,7 +62,7 @@ type planner struct {
 }
 
 func (p planner) getHalfpipeManifest() (man manifest.Manifest, err error) {
-	halfpipeFilePath, err := filechecker.GetHalfpipeFileName(p.fs, p.workingDir)
+	halfpipeFilePath, err := filechecker.GetHalfpipeFileName(p.fs, p.workingDir, config.HalfpipeFilenameOptions)
 	if err != nil {
 		return man, err
 	}


### PR DESCRIPTION
Allow to specify an input filename so that it is not necessary anymore to have sub-folders per pipeline.
This will be useful especially together with GitHub Actions as things like pull-request checks or static code analysis mit run independent of a deployment pipeline.

See also [Slack discussion](https://springernature.slack.com/archives/C01DWDGRM47/p1614952917000500).