### PR TITLE
Add linter for reserved names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20210608160410-67692ebc98de // indirect
 	code.cloudfoundry.org/cli v7.1.0+incompatible
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/bmatcuk/doublestar v1.3.4 // indirect
-	github.com/charlievieth/fs v0.0.1 // indirect
 	github.com/cloudfoundry/bosh-cli v6.4.1+incompatible
 	github.com/cloudfoundry/bosh-utils v0.0.270 // indirect
 	github.com/concourse/concourse v1.6.1-0.20200827135536-5edc00f848aa
@@ -22,13 +20,10 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/onsi/gomega v1.16.0
 	github.com/pkg/errors v0.9.1
-	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tcnksm/go-gitconfig v0.1.2
-	golang.org/x/crypto v0.0.0-20210813211128-0a44fdfbc16e // indirect
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0
@@ -37,16 +32,6 @@ require (
 require (
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b // indirect
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/tedsuo/rata v1.0.1-0.20170830210128-07d200713958 // indirect
-	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
-	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
-	golang.org/x/text v0.3.6 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/manifest/secret_validator_test.go
+++ b/manifest/secret_validator_test.go
@@ -139,6 +139,7 @@ func TestRun(t *testing.T) {
 				Vars: map[string]string{
 					"ok":         "((super.ok))",
 					"((not.ok))": "blurgh",
+					"notok": "((something.value))",
 				},
 				SaveArtifacts: []string{
 					"ok",
@@ -149,13 +150,14 @@ func TestRun(t *testing.T) {
 	}
 
 	errors := secretValidator.Validate(bad)
-	assert.Len(t, errors, 6)
+	assert.Len(t, errors, 7)
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].type"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].name"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].script"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].docker.image"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("key tasks[0].vars[((not.ok))]"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].save_artifacts[1]"))
+	assert.Contains(t, errors, manifest.ReservedSecretNameError("((something.value))", "tasks[0].vars[notok]", "value"))
 
 	good := manifest.Manifest{
 		Tasks: manifest.TaskList{


### PR DESCRIPTION
This adds a linter that errors when a secret contains a name that is reserved. This came out from a discussion in slack when their pipeline failed because the secret was `((someSecret.value))`. The secret name "value" in this case is somehow interpreted twice by vault which ultimately results in the error message

```
cannot access field 'value' of non-map value ('string') from var: someSecret.value
```

With this linter, halfpipe will error out with the following message:

```
'((someSecret.value))' at 'tasks[0].vars' uses a reserved name ('value') as key name. Reserved keywords are: ["value"]