### PR TITLE
Uses team cache also for pre-promote docker compose tasks

### DIFF
--- a/e2e/actions/deploy-cf/workflowExpected.yml
+++ b/e2e/actions/deploy-cf/workflowExpected.yml
@@ -383,7 +383,7 @@ jobs:
           -e TEST_ROUTE \
           -e VAULT_ROLE_ID \
           -e VAULT_SECRET_ID \
-          -v /mnt/halfpipe-cache/:/var/halfpipe/shared-cache \
+          -v /mnt/halfpipe-cache/halfpipe-team:/var/halfpipe/shared-cache \
           -v /var/run/docker.sock:/var/run/docker.sock \
           app
       env:

--- a/renderers/actions/deploy_cf.go
+++ b/renderers/actions/deploy_cf.go
@@ -106,7 +106,7 @@ func (a *Actions) deployCFSteps(task manifest.DeployCF, man manifest.Manifest) (
 				ppTask.Vars = make(map[string]string)
 			}
 			ppTask.Vars["TEST_ROUTE"] = testRoute
-			deploySteps = append(deploySteps, a.dockerComposeSteps(ppTask, "")...)
+			deploySteps = append(deploySteps, a.dockerComposeSteps(ppTask, man.Team)...)
 		case manifest.ConsumerIntegrationTest:
 			if ppTask.Vars == nil {
 				ppTask.Vars = make(map[string]string)


### PR DESCRIPTION
Other docker compose tasks get the team cache mounted, this got the global cache directory mounted. We think it also should be the team cache so there is no accidental sharing of the cache between teams.


Co-authored-by: Dominique Dion <dominique.dion@springernature.com>