### PR TITLE
Allows to specify a docker compose file for CDCs

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 docker run -it \
-  -v "$(go env GOMODCACHE)":/gomodcache \
   -v "$PWD":/halfpipe \
   -w /halfpipe \
   -e GOMODCACHE=/gomodcache \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 docker run -it \
+  -v "$(go env GOMODCACHE)":/gomodcache \
   -v "$PWD":/halfpipe \
   -w /halfpipe \
   -e GOMODCACHE=/gomodcache \

--- a/e2e/actions/consumer-integration-test/.halfpipe.io
+++ b/e2e/actions/consumer-integration-test/.halfpipe.io
@@ -15,6 +15,7 @@ tasks:
   provider_host: p-host
   provider_name: p-name
   script: c-script
+  docker_compose_file: custom-docker-compose.yml
   docker_compose_service: potato
   git_clone_options: "--depth 100"
   vars:

--- a/e2e/actions/consumer-integration-test/workflowExpected.yml
+++ b/e2e/actions/consumer-integration-test/workflowExpected.yml
@@ -70,8 +70,8 @@ jobs:
 
         # run the tests with docker-compose
         # note: old system reads CF manifest env vars and sets them all here
-        docker-compose pull ${DOCKER_COMPOSE_SERVICE:-code}
-        docker-compose run --no-deps \
+        docker-compose pull -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} ${DOCKER_COMPOSE_SERVICE:-code}
+        docker-compose run -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} --no-deps \
           --entrypoint "${CONSUMER_SCRIPT}" \
           -e ARTIFACTORY_PASSWORD \
           -e ARTIFACTORY_URL \
@@ -92,6 +92,7 @@ jobs:
         CONSUMER_NAME: c-consumer/sub/dir
         CONSUMER_PATH: sub/dir
         CONSUMER_SCRIPT: c-script
+        DOCKER_COMPOSE_FILE: custom-docker-compose.yml
         DOCKER_COMPOSE_SERVICE: potato
         GIT_CLONE_OPTIONS: --depth 100
         K: value
@@ -150,8 +151,8 @@ jobs:
 
         # run the tests with docker-compose
         # note: old system reads CF manifest env vars and sets them all here
-        docker-compose pull ${DOCKER_COMPOSE_SERVICE:-code}
-        docker-compose run --no-deps \
+        docker-compose pull -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} ${DOCKER_COMPOSE_SERVICE:-code}
+        docker-compose run -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} --no-deps \
           --entrypoint "${CONSUMER_SCRIPT}" \
           -e ARTIFACTORY_PASSWORD \
           -e ARTIFACTORY_URL \
@@ -172,6 +173,7 @@ jobs:
         CONSUMER_NAME: c-consumer
         CONSUMER_PATH: ""
         CONSUMER_SCRIPT: c-script
+        DOCKER_COMPOSE_FILE: ""
         DOCKER_COMPOSE_SERVICE: potato
         GIT_CLONE_OPTIONS: --depth 100
         K: value

--- a/e2e/actions/deploy-cf/workflowExpected.yml
+++ b/e2e/actions/deploy-cf/workflowExpected.yml
@@ -416,8 +416,8 @@ jobs:
 
         # run the tests with docker-compose
         # note: old system reads CF manifest env vars and sets them all here
-        docker-compose pull ${DOCKER_COMPOSE_SERVICE:-code}
-        docker-compose run --no-deps \
+        docker-compose pull -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} ${DOCKER_COMPOSE_SERVICE:-code}
+        docker-compose run -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} --no-deps \
           --entrypoint "${CONSUMER_SCRIPT}" \
           -e ARTIFACTORY_PASSWORD \
           -e ARTIFACTORY_URL \
@@ -438,6 +438,7 @@ jobs:
         CONSUMER_NAME: repo/app
         CONSUMER_PATH: app
         CONSUMER_SCRIPT: ci/run-external-and-cdcs-dev
+        DOCKER_COMPOSE_FILE: ""
         DOCKER_COMPOSE_SERVICE: ""
         GIT_CLONE_OPTIONS: ""
         PROVIDER_HOST: halfpipe-example-dev-CANDIDATE.springernature.app

--- a/e2e/concourse/consumer-integration-test/.halfpipe.io
+++ b/e2e/concourse/consumer-integration-test/.halfpipe.io
@@ -15,6 +15,7 @@ tasks:
   provider_host: p-host
   provider_name: p-name
   script: c-script
+  docker_compose_file: custom-docker-compose.yml
   docker_compose_service: potato
   git_clone_options: "--depth 100"
   vars:

--- a/e2e/concourse/consumer-integration-test/pipelineExpected.yml
+++ b/e2e/concourse/consumer-integration-test/pipelineExpected.yml
@@ -34,6 +34,7 @@ jobs:
         CONSUMER_NAME: c-consumer/sub/dir
         CONSUMER_PATH: sub/dir
         CONSUMER_SCRIPT: c-script
+        DOCKER_COMPOSE_FILE: custom-docker-compose.yml
         DOCKER_COMPOSE_SERVICE: potato
         GCR_PRIVATE_KEY: ((halfpipe-gcr.private_key))
         GIT_CLONE_OPTIONS: --depth 100
@@ -103,6 +104,7 @@ jobs:
         CONSUMER_NAME: c-consumer
         CONSUMER_PATH: ""
         CONSUMER_SCRIPT: c-script
+        DOCKER_COMPOSE_FILE: ""
         DOCKER_COMPOSE_SERVICE: potato
         GCR_PRIVATE_KEY: ((halfpipe-gcr.private_key))
         GIT_CLONE_OPTIONS: --depth 100

--- a/manifest/consumer_integration.go
+++ b/manifest/consumer_integration.go
@@ -9,6 +9,7 @@ type ConsumerIntegrationTest struct {
 	ProviderHost         string        `json:"provider_host" yaml:"provider_host,omitempty"`
 	ProviderName         string        `json:"provider_name" yaml:"provider_name,omitempty"`
 	Script               string        `yaml:"script,omitempty"`
+	DockerComposeFile    string        `json:"docker_compose_file" yaml:"docker_compose_file,omitempty"`
 	DockerComposeService string        `json:"docker_compose_service" yaml:"docker_compose_service,omitempty"`
 	Vars                 Vars          `yaml:"vars,omitempty" secretAllowed:"true"`
 	Retries              int           `yaml:"retries,omitempty"`

--- a/manifest/secret_validator_test.go
+++ b/manifest/secret_validator_test.go
@@ -343,6 +343,7 @@ func TestConsumerIntegrationTest(t *testing.T) {
 				ConsumerHost:         "((not.ok))",
 				ProviderHost:         "((not.ok))",
 				Script:               "./script ((not.ok))",
+				DockerComposeFile:    "((not.ok))",
 				DockerComposeService: "((not.ok))",
 				Vars: map[string]string{
 					"ok":         "((super.secret))",
@@ -353,13 +354,14 @@ func TestConsumerIntegrationTest(t *testing.T) {
 	}
 
 	errors := secretValidator.Validate(bad)
-	assert.Len(t, errors, 8)
+	assert.Len(t, errors, 9)
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].type"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].name"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].consumer"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].consumer_host"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].provider_host"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].script"))
+	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].docker_compose_file"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("tasks[0].docker_compose_service"))
 	assert.Contains(t, errors, manifest.UnsupportedSecretError("key tasks[0].vars[((not.ok))]"))
 }

--- a/renderers/actions/consumer_integration_tests.go
+++ b/renderers/actions/consumer_integration_tests.go
@@ -47,6 +47,7 @@ func convertConsumerIntegrationTestToRunTask(task manifest.ConsumerIntegrationTe
 			"PROVIDER_NAME":          providerName,
 			"PROVIDER_HOST_KEY":      providerHostKey,
 			"PROVIDER_HOST":          task.ProviderHost,
+			"DOCKER_COMPOSE_FILE":    task.DockerComposeFile,
 			"DOCKER_COMPOSE_SERVICE": task.DockerComposeService,
 			"GIT_CLONE_OPTIONS":      task.GitCloneOptions,
 		},

--- a/renderers/concourse/consumer_integration_tests.go
+++ b/renderers/concourse/consumer_integration_tests.go
@@ -50,6 +50,7 @@ func convertConsumerIntegrationTestToRunTask(task manifest.ConsumerIntegrationTe
 			"PROVIDER_NAME":          providerName,
 			"PROVIDER_HOST_KEY":      providerHostKey,
 			"PROVIDER_HOST":          task.ProviderHost,
+			"DOCKER_COMPOSE_FILE":    task.DockerComposeFile,
 			"DOCKER_COMPOSE_SERVICE": task.DockerComposeService,
 			"GCR_PRIVATE_KEY":        "((halfpipe-gcr.private_key))",
 			"GIT_CLONE_OPTIONS":      task.GitCloneOptions,

--- a/renderers/shared/consumer_integration_tests.go
+++ b/renderers/shared/consumer_integration_tests.go
@@ -66,8 +66,8 @@ git checkout ${REVISION}
 
 # run the tests with docker-compose
 # note: old system reads CF manifest env vars and sets them all here
-docker-compose pull ${DOCKER_COMPOSE_SERVICE:-code}
-docker-compose run --no-deps \
+docker-compose pull -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} ${DOCKER_COMPOSE_SERVICE:-code}
+docker-compose run -f ${DOCKER_COMPOSE_FILE:-docker-compose.yml} --no-deps \
   --entrypoint "${CONSUMER_SCRIPT}" \
   -e ARTIFACTORY_PASSWORD \
   -e ARTIFACTORY_URL \


### PR DESCRIPTION
We renamed our docker compose file that is used also for CDCs in our repository for cleanup as we have multiple docker compose files in the same directory. 
Now the CDCs fail for the producer as the file is not found, but there is / was no option to specify the file name.

We added this for concourse and actions. However, for concourse we cannot see where those environment variable are used, the generated pipeline calls scripts `docker.sh`or `run_cdc.sh` but they must be somewhere else?