### PR TITLE
Uses the team cache for CDCs rendered in Actions

### DIFF
--- a/e2e/actions/consumer-integration-test/workflowExpected.yml
+++ b/e2e/actions/consumer-integration-test/workflowExpected.yml
@@ -48,7 +48,7 @@ jobs:
     - name: c-name
       run: |-
         export ENV_OPTIONS="-e ARTIFACTORY_PASSWORD -e ARTIFACTORY_URL -e ARTIFACTORY_USERNAME -e K -e K1 -e S1"
-        export VOLUME_OPTIONS=""
+        export VOLUME_OPTIONS="-v /mnt/halfpipe-cache/halfpipe-team/cdcs/$CONSUMER_NAME:/var/halfpipe/shared-cache"
         run-cdc.sh
       env:
         CONSUMER_GIT_KEY: ${{ secrets.EE_GITHUB_PRIVATE_KEY }}
@@ -95,7 +95,7 @@ jobs:
     - name: c-name-covenant
       run: |-
         export ENV_OPTIONS="-e ARTIFACTORY_PASSWORD -e ARTIFACTORY_URL -e ARTIFACTORY_USERNAME -e K -e K1 -e S1"
-        export VOLUME_OPTIONS=""
+        export VOLUME_OPTIONS="-v /mnt/halfpipe-cache/halfpipe-team/cdcs/$CONSUMER_NAME:/var/halfpipe/shared-cache"
         run-cdc.sh
       env:
         CONSUMER_GIT_KEY: ${{ secrets.EE_GITHUB_PRIVATE_KEY }}

--- a/e2e/actions/deploy-cf/workflowExpected.yml
+++ b/e2e/actions/deploy-cf/workflowExpected.yml
@@ -397,7 +397,7 @@ jobs:
     - name: CDCs
       run: |-
         export ENV_OPTIONS="-e ARTIFACTORY_PASSWORD -e ARTIFACTORY_URL -e ARTIFACTORY_USERNAME -e TEST_ROUTE"
-        export VOLUME_OPTIONS=""
+        export VOLUME_OPTIONS="-v /mnt/halfpipe-cache/halfpipe-team/cdcs/$CONSUMER_NAME:/var/halfpipe/shared-cache"
         run-cdc.sh
       env:
         CONSUMER_GIT_KEY: ${{ secrets.EE_GITHUB_PRIVATE_KEY }}

--- a/renderers/actions/consumer_integration_tests.go
+++ b/renderers/actions/consumer_integration_tests.go
@@ -41,7 +41,10 @@ func convertConsumerIntegrationTestToRunTask(task manifest.ConsumerIntegrationTe
 	keys = append(keys, "ARTIFACTORY_USERNAME")
 	keys = append(keys, "ARTIFACTORY_PASSWORD")
 
-	cdcScript = shared.ConsumerIntegrationTestScript(keys, []string{})
+	var cacheDirs = []shared.CacheDirs{
+		{RunnerDir: fmt.Sprintf("/mnt/halfpipe-cache/%s/cdcs/$CONSUMER_NAME", man.Team), ContainerDir: "/var/halfpipe/shared-cache"},
+	}
+	cdcScript = shared.ConsumerIntegrationTestScript(keys, cacheDirs)
 
 	runTask := manifest.Run{
 		Retries: task.Retries,

--- a/renderers/concourse/consumer_integration_tests.go
+++ b/renderers/concourse/consumer_integration_tests.go
@@ -25,7 +25,11 @@ func convertConsumerIntegrationTestToRunTask(task manifest.ConsumerIntegrationTe
 	for k := range task.Vars {
 		keys = append(keys, k)
 	}
-	cdcScript = shared.ConsumerIntegrationTestScript(keys, config.DockerComposeCacheDirs)
+	var cacheDirs []shared.CacheDirs
+	for _, cacheDir := range config.DockerComposeCacheDirs {
+		cacheDirs = append(cacheDirs, shared.CacheDirs{RunnerDir: cacheDir, ContainerDir: cacheDir})
+	}
+	cdcScript = shared.ConsumerIntegrationTestScript(keys, cacheDirs)
 
 	script := dockerLogin + "\n" + cdcScript
 

--- a/renderers/shared/consumer_integration_tests.go
+++ b/renderers/shared/consumer_integration_tests.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 )
 
-func ConsumerIntegrationTestScript(keys []string, cacheDirs []string) string {
+type CacheDirs struct {
+	RunnerDir    string
+	ContainerDir string
+}
+
+func ConsumerIntegrationTestScript(keys []string, cacheDirs []CacheDirs) string {
 	var envStrings []string
 	for _, key := range keys {
 		envStrings = append(envStrings, fmt.Sprintf("-e %s", key))
@@ -15,8 +20,8 @@ func ConsumerIntegrationTestScript(keys []string, cacheDirs []string) string {
 	envOption := strings.Join(envStrings, " ")
 
 	var cacheVolumeFlags []string
-	for _, cacheVolume := range cacheDirs {
-		cacheVolumeFlags = append(cacheVolumeFlags, fmt.Sprintf("-v %s:%s", cacheVolume, cacheVolume))
+	for _, cache := range cacheDirs {
+		cacheVolumeFlags = append(cacheVolumeFlags, fmt.Sprintf("-v %s:%s", cache.RunnerDir, cache.ContainerDir))
 	}
 
 	volumeOption := strings.Join(cacheVolumeFlags, " ")


### PR DESCRIPTION
This mounts the team cache of the producer using a sub-directory with the consumer name as the halfpipe cache when executing the CDCs.

```
/mnt/halfpipe-cache/<producer-team>/cdcs/<consumer-name>
```

It uses a sub-directory so that cached data of the producer and consumer do not interfere.