### PR TITLE
add KATEE_PLATFORM_VERSION to DeployKatee struct

### DIFF
--- a/defaults/task_deploy_katee.go
+++ b/defaults/task_deploy_katee.go
@@ -2,7 +2,7 @@ package defaults
 
 import "github.com/springernature/halfpipe/manifest"
 
-func deploygit checkout -b <branch-name>er(original manifest.DeployKatee, defaults Defaults, man manifest.Manifest) (updated manifest.DeployKatee) {
+func deployKateeDefaulter(original manifest.DeployKatee, defaults Defaults, man manifest.Manifest) (updated manifest.DeployKatee) {
 	updated = original
 
 	if updated.VelaManifest == "" {

--- a/defaults/task_deploy_katee.go
+++ b/defaults/task_deploy_katee.go
@@ -2,7 +2,7 @@ package defaults
 
 import "github.com/springernature/halfpipe/manifest"
 
-func deployKateeDefaulter(original manifest.DeployKatee, defaults Defaults, man manifest.Manifest) (updated manifest.DeployKatee) {
+func deploygit checkout -b <branch-name>er(original manifest.DeployKatee, defaults Defaults, man manifest.Manifest) (updated manifest.DeployKatee) {
 	updated = original
 
 	if updated.VelaManifest == "" {
@@ -23,6 +23,10 @@ func deployKateeDefaulter(original manifest.DeployKatee, defaults Defaults, man 
 
 	if original.Environment == "" {
 		updated.Environment = man.Team
+	}
+
+	if original.PlatformVersion == "" {
+		updated.PlatformVersion = "v1"
 	}
 
 	return updated

--- a/defaults/task_deploy_katee_test.go
+++ b/defaults/task_deploy_katee_test.go
@@ -1,9 +1,10 @@
 package defaults
 
 import (
+	"testing"
+
 	"github.com/springernature/halfpipe/manifest"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestKateeDeployDefaults(t *testing.T) {
@@ -11,10 +12,11 @@ func TestKateeDeployDefaults(t *testing.T) {
 		man := manifest.Manifest{Team: "asdf", Platform: "actions"}
 
 		expected := manifest.DeployKatee{
-			VelaManifest: "vela.yaml",
-			Tag:          "version",
-			Namespace:    "katee-" + man.Team,
-			Environment:  "asdf",
+			VelaManifest:    "vela.yaml",
+			Tag:             "version",
+			Namespace:       "katee-" + man.Team,
+			Environment:     "asdf",
+			PlatformVersion: "v1",
 		}
 
 		assert.Equal(t, expected, deployKateeDefaulter(manifest.DeployKatee{}, Actions, man))

--- a/defaults/task_deploy_katee_test.go
+++ b/defaults/task_deploy_katee_test.go
@@ -41,4 +41,13 @@ func TestKateeDeployDefaults(t *testing.T) {
 		man := manifest.Manifest{Team: "asdf"}
 		assert.Equal(t, "blurgh", deployKateeDefaulter(manifest.DeployKatee{Environment: "blurgh"}, Actions, man).Environment)
 	})
+
+	t.Run("Does not override platform_version", func(t *testing.T) {
+		man := manifest.Manifest{Team: "asdf", Platform: "actions"}
+
+		input := manifest.DeployKatee{PlatformVersion: "v1337"}
+
+		assert.Equal(t, "v1337", deployKateeDefaulter(input, Actions, man).PlatformVersion)
+
+	})
 }

--- a/e2e/actions/deploy-katee/.halfpipe.io
+++ b/e2e/actions/deploy-katee/.halfpipe.io
@@ -32,6 +32,7 @@ tasks:
     tag: version
     namespace: katee-different-namespace
     environment: katee-different-environment
+    platform_version: v2
     notifications:
       on_failure:
         - "#ee-re"

--- a/e2e/actions/deploy-katee/workflowExpected.yml
+++ b/e2e/actions/deploy-katee/workflowExpected.yml
@@ -122,6 +122,7 @@ jobs:
         KATEE_ENVIRONMENT: halfpipe-team
         KATEE_GKE_CREDENTIALS: ${{ steps.secrets.outputs.springernature_data_halfpipe-team_katee-halfpipe-team-service-account-prod_key }}
         KATEE_NAMESPACE: katee-halfpipe-team
+        KATEE_PLATFORM_VERSION: v1
         MAX_CHECKS: "120"
         TAG: ${{ env.BUILD_VERSION }}
         VERY_SECRET: ${{ steps.secrets.outputs.springernature_data_halfpipe-team_another_secret }}
@@ -176,6 +177,7 @@ jobs:
         KATEE_ENVIRONMENT: katee-different-environment
         KATEE_GKE_CREDENTIALS: ${{ steps.secrets.outputs.springernature_data_halfpipe-team_katee-different-namespace-service-account-prod_key }}
         KATEE_NAMESPACE: katee-different-namespace
+        KATEE_PLATFORM_VERSION: v2
         TAG: ${{ env.BUILD_VERSION }}
         VERY_SECRET: ${{ steps.secrets.outputs.springernature_data_halfpipe-team_another_secret }}
     - name: 'Notify slack #ee-re (failure)'

--- a/e2e/concourse/deploy-katee/.halfpipe.io
+++ b/e2e/concourse/deploy-katee/.halfpipe.io
@@ -35,6 +35,7 @@ tasks:
     tag: version
     namespace: katee-different-namespace
     environment: katee-different-environment
+    platform_version: v2
     vela_manifest: vela.yaml
     notifications:
       on_failure:

--- a/e2e/concourse/deploy-katee/pipelineExpected.yml
+++ b/e2e/concourse/deploy-katee/pipelineExpected.yml
@@ -241,6 +241,7 @@ jobs:
         KATEE_ENVIRONMENT: halfpipe-team
         KATEE_GKE_CREDENTIALS: ((katee-halfpipe-team-service-account-prod.key))
         KATEE_NAMESPACE: katee-halfpipe-team
+        KATEE_PLATFORM_VERSION: v1
         MAX_CHECKS: "120"
         VERY_SECRET: blah
       platform: linux
@@ -345,6 +346,7 @@ jobs:
         KATEE_ENVIRONMENT: katee-different-environment
         KATEE_GKE_CREDENTIALS: ((katee-different-namespace-service-account-prod.key))
         KATEE_NAMESPACE: katee-different-namespace
+        KATEE_PLATFORM_VERSION: v2
         VERY_SECRET: blah
       platform: linux
       run:

--- a/linters/deploy-katee.go
+++ b/linters/deploy-katee.go
@@ -1,9 +1,10 @@
 package linters
 
 import (
+	"strings"
+
 	"github.com/spf13/afero"
 	"github.com/springernature/halfpipe/manifest"
-	"strings"
 )
 
 func LintDeployKateeTask(task manifest.DeployKatee, man manifest.Manifest, fs afero.Afero) (errs []error) {
@@ -19,6 +20,11 @@ func LintDeployKateeTask(task manifest.DeployKatee, man manifest.Manifest, fs af
 
 	if task.Tag == "version" && man.Platform.IsConcourse() && !man.FeatureToggles.UpdatePipeline() {
 		errs = append(errs, NewErrInvalidField("tag", "'version' requires the 'update-pipeline' feature toggle"))
+	}
+
+	// Check platform_version
+	if task.PlatformVersion != "" && task.PlatformVersion != "v1" && task.PlatformVersion != "v2" {
+		errs = append(errs, NewErrInvalidField("platform_version", "must be '', 'v1', or 'v2'"))
 	}
 
 	// vela manifest checks

--- a/manifest/deploy_katee.go
+++ b/manifest/deploy_katee.go
@@ -15,6 +15,7 @@ type DeployKatee struct {
 	Environment            string        `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Namespace              string        `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	DeploymentCheckTimeout int           `json:"deployment_check_timeout,omitempty" yaml:"deployment_check_timeout,omitempty"`
+	PlatformVersion        string        `json:"platform_version,omitempty" yaml:"platform_version,omitempty"`
 }
 
 func (d DeployKatee) ReadsFromArtifacts() bool {

--- a/renderers/actions/deploy_katee.go
+++ b/renderers/actions/deploy_katee.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"fmt"
-	"github.com/springernature/halfpipe/manifest"
 	"strconv"
+
+	"github.com/springernature/halfpipe/manifest"
 )
 
 func (a *Actions) deployKateeSteps(task manifest.DeployKatee) (steps Steps) {
@@ -14,12 +15,13 @@ func (a *Actions) deployKateeSteps(task manifest.DeployKatee) (steps Steps) {
 			"entrypoint": "/bin/sh",
 			"args":       fmt.Sprintf(`-c "cd %s; halfpipe-deploy`, a.workingDir)},
 		Env: Env{
-			"KATEE_ENVIRONMENT":     task.Environment,
-			"KATEE_NAMESPACE":       task.Namespace,
-			"KATEE_APPFILE":         task.VelaManifest,
-			"BUILD_VERSION":         "${{ env.BUILD_VERSION }}",
-			"GIT_REVISION":          "${{ env.GIT_REVISION }}",
-			"KATEE_GKE_CREDENTIALS": fmt.Sprintf("((%s-service-account-prod.key))", task.Namespace),
+			"KATEE_ENVIRONMENT":      task.Environment,
+			"KATEE_NAMESPACE":        task.Namespace,
+			"KATEE_PLATFORM_VERSION": task.PlatformVersion,
+			"KATEE_APPFILE":          task.VelaManifest,
+			"BUILD_VERSION":          "${{ env.BUILD_VERSION }}",
+			"GIT_REVISION":           "${{ env.GIT_REVISION }}",
+			"KATEE_GKE_CREDENTIALS":  fmt.Sprintf("((%s-service-account-prod.key))", task.Namespace),
 		},
 	}
 

--- a/renderers/concourse/deploy_katee.go
+++ b/renderers/concourse/deploy_katee.go
@@ -2,9 +2,10 @@ package concourse
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/springernature/halfpipe/manifest"
-	"strconv"
 )
 
 func (c Concourse) deployKateeJob(task manifest.DeployKatee, man manifest.Manifest, basePath string) (job atc.JobConfig) {
@@ -39,10 +40,11 @@ halfpipe-deploy`,
 		},
 		Privileged: false,
 		Vars: manifest.Vars{
-			"KATEE_ENVIRONMENT":     task.Environment,
-			"KATEE_NAMESPACE":       task.Namespace,
-			"KATEE_APPFILE":         task.VelaManifest,
-			"KATEE_GKE_CREDENTIALS": fmt.Sprintf(`((%s-service-account-prod.key))`, task.Namespace),
+			"KATEE_ENVIRONMENT":      task.Environment,
+			"KATEE_NAMESPACE":        task.Namespace,
+			"KATEE_PLATFORM_VERSION": task.PlatformVersion,
+			"KATEE_APPFILE":          task.VelaManifest,
+			"KATEE_GKE_CREDENTIALS":  fmt.Sprintf(`((%s-service-account-prod.key))`, task.Namespace),
 		},
 		Retries:         task.Retries,
 		NotifyOnSuccess: task.NotifyOnSuccess,


### PR DESCRIPTION
We have initiated the migration process from Katee v1 to **Katee v2**. As part of this migration, we have introduced a new environment variable `KATEE_PLATFORM_VERSION` to facilitate the transition and ensure compatibility with the new platform.

Could you please review the changes and merge into base 

Thanks for your time and assistance.  